### PR TITLE
feat: deliver qualified lead attribution

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -82,8 +82,13 @@ export default defineNuxtConfig({
       googleAdsOperatingAccountId: '',
       googleAdsLoginAccountId: '',
       googleAdsConversionActionId: '',
+      ga4MeasurementId: 'G-F4VRTJKMFH',
+      ga4MeasurementProtocolApiSecret: '',
       metaPixelId: '',
       metaConversionsApiToken: '',
+      yandexMetrikaCounterId: '110873210',
+      yandexMetrikaOAuthToken: '',
+      yandexMetrikaQualifiedGoalId: 'qualify_lead',
     },
     public: {
       ENVIROMENT: process.env.NODE_ENV,

--- a/server/api/kommo-lead.post.ts
+++ b/server/api/kommo-lead.post.ts
@@ -126,27 +126,45 @@ export default defineEventHandler(async event => {
     ['fbclid', clean(traffic.fbclid)],
     ['fbp', clean(traffic.fbp)],
     ['fbc', clean(traffic.fbc)],
+    ['yclid', clean(traffic.yclid)],
+    ['ymclientid', clean(traffic.ymclientid)],
     ['firstLandingPage', clean(traffic.first_landing_page)],
   ]
+  const utmFieldKeys = new Set<keyof typeof KOMMO_TRACKING_FIELD_NAMES>([
+    'utmSource',
+    'utmMedium',
+    'utmCampaign',
+    'utmContent',
+    'utmTerm',
+  ])
   const trackingFields = values
-    .map(([key, value]) => ({ fieldId: leadFields.get(KOMMO_TRACKING_FIELD_NAMES[key]), value }))
-    .filter((field): field is { fieldId: number; value: string } => Boolean(field.fieldId && field.value))
+    .map(([key, value]) => ({
+      fieldId: leadFields.get(KOMMO_TRACKING_FIELD_NAMES[key]),
+      value,
+      // Explicitly overwrite any CRM-side template value when this is a
+      // direct lead without a UTM parameter.
+      includeEmptyValue: utmFieldKeys.has(key),
+    }))
+    .filter(
+      (field): field is { fieldId: number; value: string; includeEmptyValue: boolean } =>
+        Boolean(field.fieldId && (field.value || field.includeEmptyValue))
+    )
+
+  const leadPayload = {
+    name: getLeadName(payload, name, phone),
+    pipeline_id: Number(config.pipelineId),
+    ...(config.statusId ? { status_id: Number(config.statusId) } : {}),
+    responsible_user_id: Number(config.responsibleUserId),
+    _embedded: { contacts: [{ id: contact.id }] },
+    custom_fields_values: trackingFields.map(({ fieldId, value }) => ({
+      field_id: fieldId,
+      values: [{ value }],
+    })),
+  }
 
   const lead = await kommoRequest<CreatedEntityResponse>(config, '/api/v4/leads', {
     method: 'POST',
-    body: JSON.stringify([
-      {
-        name: getLeadName(payload, name, phone),
-        pipeline_id: Number(config.pipelineId),
-        status_id: Number(config.statusId),
-        responsible_user_id: Number(config.responsibleUserId),
-        _embedded: { contacts: [{ id: contact.id }] },
-        custom_fields_values: trackingFields.map(({ fieldId, value }) => ({
-          field_id: fieldId,
-          values: [{ value }],
-        })),
-      },
-    ]),
+    body: JSON.stringify([leadPayload]),
   })
 
   const leadId = getCreatedEntityId(lead, 'leads')

--- a/server/api/kommo-qualified-lead.post.ts
+++ b/server/api/kommo-qualified-lead.post.ts
@@ -287,6 +287,92 @@ const sendMetaQualifiedLead = async (input: {
   return true
 }
 
+const sendGa4QualifiedLead = async (input: {
+  lead: KommoLead
+  tracking: Record<string, string>
+}) => {
+  const config = useRuntimeConfig().kommo as Record<string, string>
+  if (!config.ga4MeasurementId || !config.ga4MeasurementProtocolApiSecret) return false
+  if (!input.tracking.gclientid) return false
+
+  const query = new URLSearchParams({
+    measurement_id: config.ga4MeasurementId,
+    api_secret: config.ga4MeasurementProtocolApiSecret,
+  })
+  const response = await fetch(`https://www.google-analytics.com/mp/collect?${query}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: input.tracking.gclientid,
+      events: [
+        {
+          name: 'qualify_lead',
+          params: {
+            engagement_time_msec: 1,
+            kommo_lead_id: String(input.lead.id),
+            pipeline: QUALIFIED_PIPELINES.get(input.lead.pipeline_id) || '',
+          },
+        },
+      ],
+    }),
+  })
+
+  if (!response.ok) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `GA4 Measurement Protocol error: ${response.status}`,
+    })
+  }
+
+  return true
+}
+
+const csvValue = (value: string) => `"${value.replaceAll('"', '""')}"`
+
+const sendYandexQualifiedLead = async (input: {
+  lead: KommoLead
+  tracking: Record<string, string>
+}) => {
+  const config = useRuntimeConfig().kommo as Record<string, string>
+  if (
+    !config.yandexMetrikaCounterId ||
+    !config.yandexMetrikaOAuthToken ||
+    !config.yandexMetrikaQualifiedGoalId
+  ) {
+    return false
+  }
+  if (!input.tracking.ymclientid && !input.tracking.yclid) return false
+
+  const headers = ['Target', 'DateTime', 'ClientId', 'Yclid']
+  const record = [
+    config.yandexMetrikaQualifiedGoalId,
+    String(Math.floor(Date.now() / 1000)),
+    input.tracking.ymclientid || '',
+    input.tracking.yclid || '',
+  ]
+  const csv = `${headers.join(',')}\n${record.map(csvValue).join(',')}\n`
+  const form = new FormData()
+  form.set('file', new Blob([csv], { type: 'text/csv;charset=utf-8' }), 'qualified-lead.csv')
+
+  const response = await fetch(
+    `https://api-metrika.yandex.net/management/v1/counter/${config.yandexMetrikaCounterId}/offline_conversions/upload?type=BASIC&comment=Kommo%20qualified%20lead`,
+    {
+      method: 'POST',
+      headers: { Authorization: `OAuth ${config.yandexMetrikaOAuthToken}` },
+      body: form,
+    }
+  )
+
+  if (!response.ok) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `Yandex Metrika offline conversion error: ${response.status}`,
+    })
+  }
+
+  return true
+}
+
 export default defineEventHandler(async event => {
   const config = getKommoConfig()
   const secret = getQuery(event).key
@@ -353,6 +439,42 @@ export default defineEventHandler(async event => {
     const metaSent = await sendMetaQualifiedLead({ lead, contact, tracking })
     destinations.meta = metaSent ? 'sent' : 'not_configured'
     if (metaSent) await updateLeadField(config, lead, metaFieldId)
+  }
+
+  const ga4FieldId = await ensureLeadField(
+    config,
+    fieldMap,
+    KOMMO_TRACKING_FIELD_NAMES.qualifiedGa4SentAt
+  )
+  const ga4Configured = Boolean(
+    value((useRuntimeConfig().kommo as Record<string, string>).ga4MeasurementProtocolApiSecret)
+  )
+  if (!ga4Configured) {
+    destinations.ga4 = 'not_configured'
+  } else if (getLeadFieldValue(lead, ga4FieldId)) {
+    destinations.ga4 = 'duplicate'
+  } else {
+    const ga4Sent = await sendGa4QualifiedLead({ lead, tracking })
+    destinations.ga4 = ga4Sent ? 'sent' : 'not_attributable'
+    if (ga4Sent) await updateLeadField(config, lead, ga4FieldId)
+  }
+
+  const yandexFieldId = await ensureLeadField(
+    config,
+    fieldMap,
+    KOMMO_TRACKING_FIELD_NAMES.qualifiedYandexSentAt
+  )
+  const yandexConfigured = Boolean(
+    value((useRuntimeConfig().kommo as Record<string, string>).yandexMetrikaOAuthToken)
+  )
+  if (!yandexConfigured) {
+    destinations.yandex = 'not_configured'
+  } else if (getLeadFieldValue(lead, yandexFieldId)) {
+    destinations.yandex = 'duplicate'
+  } else {
+    const yandexSent = await sendYandexQualifiedLead({ lead, tracking })
+    destinations.yandex = yandexSent ? 'sent' : 'not_attributable'
+    if (yandexSent) await updateLeadField(config, lead, yandexFieldId)
   }
 
   return { ok: true, qualified: true, destinations }

--- a/server/utils/kommo.ts
+++ b/server/utils/kommo.ts
@@ -2,7 +2,7 @@ type KommoConfig = {
   subdomain: string
   longLivedToken: string
   pipelineId: string
-  statusId: string
+  statusId?: string
   responsibleUserId: string
   qualifiedWebhookSecret?: string
   googleDataManagerClientId?: string
@@ -35,9 +35,13 @@ export const KOMMO_TRACKING_FIELD_NAMES = {
   fbclid: 'fbclid',
   fbp: 'fbp',
   fbc: 'fbc',
+  yclid: 'yclid',
+  ymclientid: 'ymclientid',
   firstLandingPage: 'first_landing_page',
   qualifiedGoogleSentAt: 'qlead_google_sent_at',
   qualifiedMetaSentAt: 'qlead_meta_sent_at',
+  qualifiedGa4SentAt: 'qlead_ga4_sent_at',
+  qualifiedYandexSentAt: 'qlead_yandex_sent_at',
 } as const
 
 export const getKommoConfig = (): KommoConfig => {
@@ -46,7 +50,6 @@ export const getKommoConfig = (): KommoConfig => {
     'subdomain',
     'longLivedToken',
     'pipelineId',
-    'statusId',
     'responsibleUserId',
   ].filter(key => !config[key as keyof KommoConfig])
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,5 +5,10 @@ export {}
 declare global {
   interface Window {
     escroll: typeof EmotionScroll.prototype
+    ym?: (
+      counterId: number,
+      method: 'getClientID',
+      callback: (clientId: string) => void
+    ) => void
   }
 }

--- a/utils/trafficSource.ts
+++ b/utils/trafficSource.ts
@@ -21,6 +21,7 @@ export type TrafficSource = Partial<
   gclientid?: string
   fbp?: string
   fbc?: string
+  ymclientid?: string
 }
 
 const getCookie = (name: string) =>
@@ -40,7 +41,9 @@ const getGoogleClientId = () => {
 
 const readStoredTrafficSource = (): TrafficSource => {
   try {
-    const raw = window.localStorage.getItem(TRAFFIC_SOURCE_STORAGE_KEY)
+    // Attribution must not leak into a later direct visit. Keep it only while
+    // the visitor stays in the current browser session.
+    const raw = window.sessionStorage.getItem(TRAFFIC_SOURCE_STORAGE_KEY)
     return raw ? JSON.parse(raw) : {}
   } catch {
     return {}
@@ -49,9 +52,22 @@ const readStoredTrafficSource = (): TrafficSource => {
 
 const writeStoredTrafficSource = (value: TrafficSource) => {
   try {
-    window.localStorage.setItem(TRAFFIC_SOURCE_STORAGE_KEY, JSON.stringify(value))
+    window.sessionStorage.setItem(TRAFFIC_SOURCE_STORAGE_KEY, JSON.stringify(value))
   } catch {
     // Ignore storage errors; current URL data can still be attached to leads.
+  }
+}
+
+const captureYandexClientId = (stored: TrafficSource) => {
+  if (stored.ymclientid || typeof window.ym !== 'function') return
+
+  try {
+    window.ym(110873210, 'getClientID', (clientId: string) => {
+      if (!clientId) return
+      writeStoredTrafficSource({ ...readStoredTrafficSource(), ymclientid: clientId })
+    })
+  } catch {
+    // The Metrika counter can be unavailable during an early page load.
   }
 }
 
@@ -60,6 +76,7 @@ export const captureTrafficSource = (): TrafficSource => {
 
   const params = new URLSearchParams(window.location.search)
   const stored = readStoredTrafficSource()
+  captureYandexClientId(stored)
   const next: TrafficSource = {
     ...stored,
     first_landing_page: stored.first_landing_page || window.location.href,


### PR DESCRIPTION
Delivers qualified leads from Kommo workflows to Google Ads, GA4, Meta CAPI and Yandex Metrika. Includes direct-lead UTM clearing and attribution identifiers.