### PR TITLE
fix: use Yandex qualified lead goal id

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -88,7 +88,7 @@ export default defineNuxtConfig({
       metaConversionsApiToken: '',
       yandexMetrikaCounterId: '110873210',
       yandexMetrikaOAuthToken: '',
-      yandexMetrikaQualifiedGoalId: 'qualify_lead',
+      yandexMetrikaQualifiedGoalId: '586798746',
     },
     public: {
       ENVIROMENT: process.env.NODE_ENV,


### PR DESCRIPTION
Sets the offline QLead target to the configured Yandex Metrika goal ID `586798746`.