### PR TITLE
Fix Yandex qualified lead delivery

### DIFF
--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -128,6 +128,11 @@ QLead не является браузерным событием и не про
   Conversion `QLead`.
 - Яндекс: offline conversion в цель `586798746`.
 
+Для offline conversion Метрики сервер отправляет ровно один идентификатор:
+`Yclid`, если он есть, иначе `ClientId` (`ymclientid`). `DateTime` всегда
+нормализуется в прошедшее время, как требует API Метрики. ID загрузки и тип
+использованного идентификатора сохраняются в `qlead_yandex_detail`.
+
 ## 6. Где лежат настройки и секреты
 
 - Публичные ID находятся в `nuxt.config.ts` и в этом документе. Для Google Ads
@@ -205,6 +210,8 @@ QLead не является браузерным событием и не про
 4. Повторно сохранить стадию и убедиться, что вторых отправок нет.
 5. Проверить диагностику Google Ads, GA4 Realtime/DebugView, Meta Test Events и
    историю offline upload Метрики. Обработка Метрики может быть асинхронной.
+6. В Vercel Runtime Logs найти запись `Qualified lead delivery result` по ID
+   лида. В ней должны быть результаты всех четырёх каналов без значений секретов.
 
 ## 10. Диагностика
 
@@ -217,6 +224,7 @@ QLead не является браузерным событием и не про
 | QLead `not_configured` | соответствующая Production env variable |
 | QLead `retrying` | `qlead_*_detail` и Vercel runtime logs |
 | Метрика не показывает QLead сразу | проверить upload ID и статус обработки |
+| Метрика отклонила offline conversion | проверить `id:Yclid` или `id:ClientId` в `qlead_yandex_detail` и что `DateTime` не находится в будущем |
 
 ## 11. Ответственность и резервный доступ
 

--- a/server/api/kommo-qualified-lead.post.ts
+++ b/server/api/kommo-qualified-lead.post.ts
@@ -22,6 +22,7 @@ import {
   normalizeGooglePhone,
   normalizeMetaPhone,
 } from '~/server/utils/providerUserData'
+import { buildYandexOfflineConversionCsv } from '~/server/utils/yandexOfflineConversion'
 
 export const QLEAD_CHANNELS = ['google', 'meta', 'ga4', 'yandex'] as const
 
@@ -390,8 +391,6 @@ const sendGa4QualifiedLead = async (input: {
   }
 }
 
-const csvValue = (value: string) => `"${value.replaceAll('"', '""')}"`
-
 const sendYandexQualifiedLead = async (input: {
   lead: KommoLead
   tracking: Record<string, string>
@@ -415,16 +414,22 @@ const sendYandexQualifiedLead = async (input: {
     return { sent: false, detail: 'No Yandex ClientID or yclid' }
   }
 
-  const headers = ['Target', 'DateTime', 'ClientId', 'Yclid']
-  const record = [
-    config.yandexMetrikaQualifiedGoalId,
-    String(input.qualifiedAt),
-    input.tracking.ymclientid || '',
-    input.tracking.yclid || '',
-  ]
-  const csv = `${headers.join(',')}\n${record.map(csvValue).join(',')}\n`
+  const offlineConversion = buildYandexOfflineConversionCsv({
+    goalId: config.yandexMetrikaQualifiedGoalId,
+    qualifiedAt: input.qualifiedAt,
+    clientId: input.tracking.ymclientid,
+    yclid: input.tracking.yclid,
+  })
+  if (!offlineConversion) {
+    return { sent: false, detail: 'No Yandex ClientID or yclid' }
+  }
+
   const form = new FormData()
-  form.set('file', new Blob([csv], { type: 'text/csv;charset=utf-8' }), 'qualified-lead.csv')
+  form.set(
+    'file',
+    new Blob([offlineConversion.csv], { type: 'text/csv;charset=utf-8' }),
+    'qualified-lead.csv'
+  )
 
   const response = await fetch(
     `https://api-metrika.yandex.net/management/v1/counter/${config.yandexMetrikaCounterId}/offline_conversions/upload?type=BASIC&comment=Kommo%20qualified%20lead`,
@@ -456,7 +461,7 @@ const sendYandexQualifiedLead = async (input: {
 
   return {
     sent: true,
-    detail: `upload:${responseBody.uploading.id}; status:${responseBody.uploading.status || 'UPLOADED'}`,
+    detail: `upload:${responseBody.uploading.id}; status:${responseBody.uploading.status || 'UPLOADED'}; id:${offlineConversion.identifierType}`,
   }
 }
 
@@ -503,9 +508,16 @@ const getChannelConfigurationStatus = (
     return Boolean(runtimeConfig.metaPixelId && runtimeConfig.metaConversionsApiToken)
   }
   if (channel === 'ga4') {
-    return Boolean(runtimeConfig.ga4MeasurementProtocolApiSecret)
+    return Boolean(
+      runtimeConfig.ga4MeasurementId &&
+      runtimeConfig.ga4MeasurementProtocolApiSecret
+    )
   }
-  return Boolean(runtimeConfig.yandexMetrikaOAuthToken)
+  return Boolean(
+    runtimeConfig.yandexMetrikaCounterId &&
+    runtimeConfig.yandexMetrikaOAuthToken &&
+    runtimeConfig.yandexMetrikaQualifiedGoalId
+  )
 }
 
 const qleadDetail = (message: string) => message.slice(0, 240)
@@ -730,9 +742,14 @@ export default defineEventHandler(async event => {
 
   const failedChannels = deliveries
     .map((delivery, index) =>
-      delivery.status === 'rejected' ? QLEAD_CHANNELS[index] : undefined
+      delivery.status === 'rejected' ||
+      (delivery.status === 'fulfilled' && delivery.value[1] === 'not_configured')
+        ? QLEAD_CHANNELS[index]
+        : undefined
     )
     .filter((channel): channel is QLeadChannel => Boolean(channel))
+
+  console.info('Qualified lead delivery result', { leadId, results })
 
   if (failedChannels.length) {
     throw createError({

--- a/server/utils/yandexOfflineConversion.ts
+++ b/server/utils/yandexOfflineConversion.ts
@@ -1,0 +1,31 @@
+type YandexOfflineConversionInput = {
+  goalId: string
+  qualifiedAt: number
+  now?: number
+  clientId?: string
+  yclid?: string
+}
+
+const csvValue = (value: string) => `"${value.replaceAll('"', '""')}"`
+
+export const buildYandexOfflineConversionCsv = (
+  input: YandexOfflineConversionInput
+) => {
+  const yclid = String(input.yclid || '').trim()
+  const clientId = String(input.clientId || '').trim()
+  const identifierName = yclid ? 'Yclid' : clientId ? 'ClientId' : ''
+  const identifierValue = yclid || clientId
+
+  if (!identifierName || !identifierValue) return undefined
+
+  const now = Math.floor(input.now || Date.now() / 1000)
+  const requestedTimestamp = Math.floor(input.qualifiedAt || now - 1)
+  const conversionTimestamp = Math.max(1, Math.min(requestedTimestamp, now - 1))
+  const headers = ['Target', 'DateTime', identifierName]
+  const record = [input.goalId, String(conversionTimestamp), identifierValue]
+
+  return {
+    csv: `${headers.join(',')}\n${record.map(csvValue).join(',')}\n`,
+    identifierType: identifierName,
+  }
+}

--- a/tests/yandex-offline-conversion.test.ts
+++ b/tests/yandex-offline-conversion.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { buildYandexOfflineConversionCsv } from '../server/utils/yandexOfflineConversion.ts'
+
+test('Yandex offline conversion prefers yclid and sends one identifier type', () => {
+  const result = buildYandexOfflineConversionCsv({
+    goalId: '586798746',
+    qualifiedAt: 100,
+    now: 200,
+    clientId: 'client-1',
+    yclid: 'click-1',
+  })
+
+  assert.equal(result?.identifierType, 'Yclid')
+  assert.equal(
+    result?.csv,
+    'Target,DateTime,Yclid\n"586798746","100","click-1"\n'
+  )
+  assert.equal(result?.csv.includes('ClientId'), false)
+})
+
+test('Yandex offline conversion falls back to ClientId', () => {
+  const result = buildYandexOfflineConversionCsv({
+    goalId: '586798746',
+    qualifiedAt: 100,
+    now: 200,
+    clientId: 'client-1',
+  })
+
+  assert.equal(result?.identifierType, 'ClientId')
+  assert.equal(
+    result?.csv,
+    'Target,DateTime,ClientId\n"586798746","100","client-1"\n'
+  )
+})
+
+test('Yandex conversion timestamp is always in the past', () => {
+  const result = buildYandexOfflineConversionCsv({
+    goalId: '586798746',
+    qualifiedAt: 250,
+    now: 200,
+    clientId: 'client-1',
+  })
+
+  assert.equal(
+    result?.csv,
+    'Target,DateTime,ClientId\n"586798746","199","client-1"\n'
+  )
+})
+
+test('Yandex offline conversion requires an attribution identifier', () => {
+  assert.equal(
+    buildYandexOfflineConversionCsv({
+      goalId: '586798746',
+      qualifiedAt: 100,
+      now: 200,
+    }),
+    undefined
+  )
+})


### PR DESCRIPTION
## Что изменено
- отправка QLead в Метрику использует ровно один идентификатор: `Yclid`, иначе `ClientId`
- `DateTime` гарантированно находится в прошлом
- неполная production-конфигурация канала больше не маскируется успешным ответом
- в runtime logs добавлен безопасный сводный результат четырёх QLead-каналов
- добавлены тесты и обновлён операционный регламент

## Проверка
- 16/16 Node tests
- ESLint
- Nuxt production build